### PR TITLE
[MR-5757] fix deprecated null prefix

### DIFF
--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -168,7 +168,7 @@ class FacebookRedirectLoginHelper
             'access_token' => $accessToken->getValue(),
         ];
 
-        return 'https://www.facebook.com/logout.php?' . http_build_query($params, null, $separator);
+        return 'https://www.facebook.com/logout.php?' . http_build_query($params, '', $separator);
     }
 
     /**

--- a/src/Facebook/Http/RequestBodyMultipart.php
+++ b/src/Facebook/Http/RequestBodyMultipart.php
@@ -144,7 +144,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      */
     private function getNestedParams(array $params)
     {
-        $query = http_build_query($params, null, '&');
+        $query = http_build_query($params, '', '&');
         $params = explode('&', $query);
         $result = [];
 

--- a/src/Facebook/Http/RequestBodyUrlEncoded.php
+++ b/src/Facebook/Http/RequestBodyUrlEncoded.php
@@ -50,6 +50,6 @@ class RequestBodyUrlEncoded implements RequestBodyInterface
      */
     public function getBody()
     {
-        return http_build_query($this->params, null, '&');
+        return http_build_query($this->params, '', '&');
     }
 }

--- a/src/Facebook/Url/FacebookUrlManipulator.php
+++ b/src/Facebook/Url/FacebookUrlManipulator.php
@@ -57,7 +57,7 @@ class FacebookUrlManipulator
             }
 
             if (count($params) > 0) {
-                $query = '?' . http_build_query($params, null, '&');
+                $query = '?' . http_build_query($params, '', '&');
             }
         }
 
@@ -85,7 +85,7 @@ class FacebookUrlManipulator
         }
 
         if (strpos($url, '?') === false) {
-            return $url . '?' . http_build_query($newParams, null, '&');
+            return $url . '?' . http_build_query($newParams, '', '&');
         }
 
         list($path, $query) = explode('?', $url, 2);
@@ -98,7 +98,7 @@ class FacebookUrlManipulator
         // Sort for a predicable order
         ksort($newParams);
 
-        return $path . '?' . http_build_query($newParams, null, '&');
+        return $path . '?' . http_build_query($newParams, '', '&');
     }
 
     /**


### PR DESCRIPTION
Argument `$numeric_prefix` funkce `http_build_query` musí být string: https://www.php.net/manual/en/function.http-build-query.php

https://munipolis.sentry.io/issues/4772517701/
https://munipolis.sentry.io/issues/4772517526/
https://munipolis.sentry.io/issues/4772517584/
https://munipolis.sentry.io/issues/4772517698/

[MR-5757]

[MR-5757]: https://neogenia.atlassian.net/browse/MR-5757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ